### PR TITLE
Use ENV to get paths for binaries, this helps it work on not only debian/ubuntu, but FreeBSD as well

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'json', '1.8.1'
+gem 'json', '1.8.2'
 gem 'httparty', '0.13.1'
 gem 'mail', '2.6.3'
 gem 'logger', '1.2.8'

--- a/bin/plexreport
+++ b/bin/plexreport
@@ -1,4 +1,4 @@
-#!/usr/bin/ruby
+#!/usr/bin/env ruby
 require 'rubygems'
 require 'bundler/setup'
 require 'time'

--- a/bin/plexreport-setup
+++ b/bin/plexreport-setup
@@ -1,4 +1,4 @@
-#!/usr/bin/ruby
+#!/usr/bin/env ruby
 require 'rubygems'
 require 'json'
 require 'httparty'

--- a/initial_setup.sh
+++ b/initial_setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/env bash
 # Bash script that copies plexreport files to various directories
 # and walks the user through the initial setup
 #
@@ -24,7 +24,8 @@ PLEX_REPORT_CONF='/etc/plexReport'
 /usr/bin/touch /var/log/plexReport.log
 
 /bin/echo "Installing ruby gem dependency"
-/usr/bin/gem install bundler
+GEM_BINARY=$(which gem)
+$GEM_BINARY install bundler
 /usr/local/bin/bundle install
 
 /bin/echo "Running /usr/local/sbin/plexreport-setup"

--- a/initial_setup.sh
+++ b/initial_setup.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 # Bash script that copies plexreport files to various directories
 # and walks the user through the initial setup
 #


### PR DESCRIPTION
These changes were necessary to work on FreeBSD, and will help in other OS's as well.  Use ENV to get path rather than hard coding to /usr/bin, etc.